### PR TITLE
Change module addition commands to singular form

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ npx xacos init api-server --ts --prisma --redis --docker
 Creates a complete module with controller, service, model, and routes.
 
 ```bash
-npx xacos add Users
-npx xacos add notifications
-npx xacos add products
+npx xacos add User
+npx xacos add notification
+npx xacos add product
 ```
 
 This command generates:
@@ -201,7 +201,7 @@ my-backend/
 2. **Add a module:**
    ```bash
    cd my-api
-   npx xacos add Users
+   npx xacos add User
    ```
 
 3. **Install dependencies:**


### PR DESCRIPTION
Updated commands in README to reflect singular module naming. It creates an extra "s" while making them plural in the controller, service, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README examples with corrected module naming conventions.
  * Revised initialization and Quick Start sections with standardized command syntax examples.
  * Improved documentation accuracy and consistency across all code examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->